### PR TITLE
Generate file with good Fonts

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,13 +16,13 @@ const filePath = process.argv[2];
     if (err)
       return console.log(err); //Handle error
     if (stats.isFile()) {
-      console.log('PROCESSING FILE========= ')
-      convertFile(filePath)
+      console.log('PROCESSING FILE========= ');
+      convertFile(filePath);
     } else if (stats.isDirectory()) {
       console.log('PROCESSING DIRECTORY========= ')
       recursive(filePath, ["foo.cs", "*.html", "*.jpg", "*.png", "*.svg"], function(err, files) {
         const numPromise = async.mapLimit(files, 1, async function(filePath) {
-          return convertFile(filePath)
+          return convertFile(filePath);
         })
         return numPromise.then((result) => console.log(result)).catch(() => {})
       })
@@ -31,18 +31,18 @@ const filePath = process.argv[2];
 })()
 
 const isValidFileSize = (file) => {
-  return fs.statSync(file)["size"] < 4000000
+  return fs.statSync(file)["size"] < 4000000;
 }
 
 const isValidFile = ext => {
-  let allowed_ext = ['.pdf']
-  return allowed_ext.includes(ext)
+  let allowed_ext = ['.pdf'];
+  return allowed_ext.includes(ext);
 }
 
 const stripText = function(str) {
   // removes <Text> tags in the SVG - optional
-  str = str.replace(/<text[\s\S]+?<\/text>/g, '')
-  return str
+  str = str.replace(/<text[\s\S]+?<\/text>/g, '');
+  return str;
 }
 
 const convertFile = filePath => {
@@ -51,12 +51,13 @@ const convertFile = filePath => {
     if (isValidFile(file.ext) && isValidFileSize(filePath)) {
       new Promise((resolve, reject) => {
         const inkscape = new Inkscape([
+          '--export-text-to-path',
           '--export-plain-svg',
           '--export-area-drawing',
           '--import-pdf'
         ]);
 
-        const outputSVG = filePath + '.svg'
+        const outputSVG = filePath + '.svg'; // Remove original file extention.
 
         const SvgStream = fs.createWriteStream(outputSVG);
 
@@ -70,13 +71,13 @@ const convertFile = filePath => {
         fs.createReadStream(filePath).pipe(inkscape).pipe(removeTextTags).pipe(SvgStream)
 
         SvgStream.on("finish", function() {
-          console.log(`FINISHED - ${filePath}`)
+          console.log(`FINISHED - ${filePath}`);
           resolve();
         });
       });
-      return file
+      return file;
     }
   } catch (e) {
-    console.log(e)
+    console.log(e);
   }
 }

--- a/index.js
+++ b/index.js
@@ -51,10 +51,11 @@ const convertFile = filePath => {
     if (isValidFile(file.ext) && isValidFileSize(filePath)) {
       new Promise((resolve, reject) => {
         const inkscape = new Inkscape([
+          '--pdf-poppler',
           '--export-text-to-path',
           '--export-plain-svg',
-          '--export-area-drawing',
-          '--import-pdf'
+          '--export-area-drawing'
+          //'--import-pdf'
         ]);
 
         const outputSVG = filePath + '.svg'; // Remove original file extention.


### PR DESCRIPTION
Adding "Export Text to Path" (--export-text-to-path) to generate SVG files with good fonts. 
[File example that will not come with fonts.](https://cdn.voome.org/api-media/custom_upload/1/arquivo.pdf)
Also added some ";" just to be compliant with the rest of the code (nothing special).

More info: https://inkscape.org/doc/inkscape-man.html

-T, --export-text-to-path
Convert text objects to paths on export, where applicable (for PS, EPS, PDF and SVG export).